### PR TITLE
Switch to module Firebase setup

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -6,9 +6,6 @@
   <title>📊 Analysis</title>
   <link rel="stylesheet" href="style.css"/>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 </head>
 <body>
   <header>
@@ -51,6 +48,6 @@
   <footer>
     <p>&copy; 2025 Dynasty League Manager</p>
   </footer>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
   <title>🏈 Dynasty Fantasy Football League</title>
   <link rel="stylesheet" href="style.css"/>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 </head>
 <body>
   <header>
@@ -45,6 +42,18 @@
       <div id="event-log" style="display:none;">Loading...</div>
     </section>
 
+    <section id="draft-dashboard">
+      <h2>📝 Draft Dashboard</h2>
+      <table id="draft-table">
+        <thead>
+          <tr>
+            <th>Pick</th><th>Team</th><th>Player</th><th>Grade</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
     <section id="champions-section">
       <h2>🏆 Past Champions</h2>
       <div id="champion-gallery">
@@ -55,12 +64,20 @@
         </ul>
       </div>
     </section>
+
+    <section id="commish-notes">
+      <h2>🗒️ Commissioner Notes</h2>
+      <div id="notes-display">Loading...</div>
+      <textarea id="notes-editor" style="display:none;" rows="5"></textarea>
+      <button id="edit-notes-btn" style="display:none;">Edit</button>
+      <button id="save-notes-btn" style="display:none;">Save</button>
+    </section>
   </main>
 
   <footer>
     <p>&copy; 2025 Dynasty League Manager</p>
   </footer>
 
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/rules.html
+++ b/rules.html
@@ -5,9 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>📜 Rules & Polls</title>
   <link rel="stylesheet" href="style.css"/>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <!-- Firebase modules imported in script.js -->
 </head>
 <body>
   <header>
@@ -49,6 +47,6 @@
   <footer>
     <p>&copy; 2025 Dynasty League Manager</p>
   </footer>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,14 +5,18 @@
    – Firebase, Dark Mode, Auth, Utility
    ======================================= */
 
-// Initialize Firebase
-firebase.initializeApp({
+import { initializeApp } from "https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js";
+import { getAuth, onAuthStateChanged, signInWithPopup, GoogleAuthProvider, signOut } from "https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js";
+import { getFirestore, collection, doc, getDoc, setDoc, onSnapshot, query, orderBy, limit } from "https://www.gstatic.com/firebasejs/12.0.0/firebase-firestore.js";
+
+const firebaseConfig = {
   apiKey:    "AIzaSyBTY-rF1jHLFyPjtQ5NVNTKAO7_9ts8MjI",
   authDomain:"dynastyboard.firebaseapp.com",
   projectId: "dynastyboard"
-});
-const db   = firebase.firestore();
-const auth = firebase.auth();
+};
+const app  = initializeApp(firebaseConfig);
+const db   = getFirestore(app);
+const auth = getAuth(app);
 
 // Dark Mode: respect OS setting & toggle
 (function(){
@@ -35,14 +39,31 @@ function toggleSection(id) {
 }
 window.toggleSection = toggleSection;
 
-// Authentication (stubs for future)
+// Authentication helpers
 let currentUser = null;
-auth.onAuthStateChanged(u => {
+const adminUid = "ADMIN_UID"; // replace with your Firebase UID
+
+function startLogin() {
+  const provider = new GoogleAuthProvider();
+  signInWithPopup(auth, provider).catch(console.error);
+}
+window.startLogin = startLogin;
+
+function logout() {
+  signOut(auth).catch(console.error);
+}
+window.logout = logout;
+
+onAuthStateChanged(auth, u => {
   currentUser = u;
-  // here you could show/hide login buttons if implemented
+  document.getElementById("login-btn")?.style.display = u ? "none" : "inline";
+  document.getElementById("logout-btn")?.style.display = u ? "inline" : "none";
+  const canEdit = u && u.uid === adminUid;
+  document.getElementById("edit-notes-btn")?.style.setProperty("display", canEdit ? "inline" : "none");
   loadPolls();
   loadRules();
   loadEvents();
+  loadNotes();
 });
 
 
@@ -54,6 +75,7 @@ auth.onAuthStateChanged(u => {
 // Your Sleeper league IDs
 const leagueId         = "1180208789911158784";
 const fallbackLeagueId = "1048313545995296768";
+const draftId          = "1234567890"; // Update with current draft ID
 
 // 1) League Info (header)
 async function fetchLeagueInfo() {
@@ -169,10 +191,8 @@ async function loadEvents() {
   ]);
   const userMap = Object.fromEntries(users.map(u => [u.user_id, u.display_name]));
 
-  db.collection("events")
-    .orderBy("timestamp","desc")
-    .limit(20)
-    .onSnapshot(async snap => {
+  const q = query(collection(db,"events"), orderBy("timestamp","desc"), limit(20));
+  onSnapshot(q, async snap => {
       let docs = snap.docs.map(d => {
         const e = d.data();
         return {
@@ -242,6 +262,49 @@ function analyzeTrade(){}
 function drawTrendChart(){}
 function drawAgeCurve(){}
 
+// Commissioner Notes
+const notesRef = doc(db, "config", "notes");
+
+async function loadNotes() {
+  const disp = document.getElementById("notes-display");
+  const edit = document.getElementById("notes-editor");
+  if (!disp) return;
+  const snap = await getDoc(notesRef);
+  const text = snap.exists() ? snap.data().text : "";
+  disp.innerText = text;
+  if (edit) edit.value = text;
+}
+window.loadNotes = loadNotes;
+
+document.getElementById("edit-notes-btn")?.addEventListener("click", () => {
+  document.getElementById("notes-editor").style.display = "block";
+  document.getElementById("save-notes-btn").style.display = "inline";
+  document.getElementById("edit-notes-btn").style.display = "none";
+});
+
+document.getElementById("save-notes-btn")?.addEventListener("click", async () => {
+  const text = document.getElementById("notes-editor").value;
+  await setDoc(notesRef, { text });
+  document.getElementById("notes-editor").style.display = "none";
+  document.getElementById("save-notes-btn").style.display = "none";
+  document.getElementById("edit-notes-btn").style.display = "inline";
+  loadNotes();
+});
+
+// Draft Dashboard (basic starter)
+async function loadDraft() {
+  const body = document.querySelector("#draft-table tbody");
+  if (!body) return;
+  try {
+    const picks = await fetch(`https://api.sleeper.app/v1/draft/${draftId}/picks`).then(r=>r.json());
+    const rows = picks.map(p => `<tr><td>${p.pick_no}</td><td>${p.roster_id}</td><td>${p.player_id}</td><td>—</td></tr>`).join("");
+    body.innerHTML = rows;
+  } catch(e) {
+    console.error("loadDraft error", e);
+  }
+}
+window.loadDraft = loadDraft;
+
 // ————————————————————————
 // Dynamic Past Champions
 // ————————————————————————
@@ -292,11 +355,7 @@ window.addEventListener("load", () => {
   fetchLeagueInfo();
   fetchStandings();
   loadEvents();
-   window.addEventListener("load", () => {
-  fetchLeagueInfo();
-  fetchStandings();
-  loadEvents();
-  fetchChampions(); 
-});
-
+  fetchChampions();
+  loadDraft();
+  loadNotes();
 });

--- a/teams.html
+++ b/teams.html
@@ -8,10 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>🧑‍🤝‍🧑 Dynasty League — Teams</title>
   <link rel="stylesheet" href="style.css"/>
-  <!-- Firebase SDKs (needed for script.js) -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <!-- Firebase SDKs are imported via script.js -->
 </head>
 <body>
   <!-- =======================================
@@ -54,6 +51,6 @@
   </footer>
 
   <!-- Page Logic -->
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch HTML files to load script.js as a module
- add draft dashboard and commissioner notes sections on the home page
- use Firebase modular SDK in script.js
- add simple login helpers and Firestore-based notes
- basic draft table loading logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f0fd70cd08333a12baffcd650e05b