### PR TITLE
Fix double load handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -292,11 +292,5 @@ window.addEventListener("load", () => {
   fetchLeagueInfo();
   fetchStandings();
   loadEvents();
-   window.addEventListener("load", () => {
-  fetchLeagueInfo();
-  fetchStandings();
-  loadEvents();
-  fetchChampions(); 
-});
-
+  fetchChampions();
 });


### PR DESCRIPTION
## Summary
- remove nested `window.addEventListener("load")` block
- call all init functions from a single load handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f0fd49fc88333889127a18d327aca